### PR TITLE
🦞 fix: pass discord_bot as keyword argument to AutonomousEngine

### DIFF
--- a/autonomous-ai-server.py
+++ b/autonomous-ai-server.py
@@ -697,7 +697,7 @@ _discord_token = os.getenv("DISCORD_BOT_TOKEN", "")
 if _discord_token and _discord_token != "your_token_here":
     discord_bot = DiscordBot(claude)
 
-autonomous_engine = AutonomousEngine(claude, context_collector, discord_bot)
+autonomous_engine = AutonomousEngine(claude, context_collector, discord_bot=discord_bot)
 
 
 # Request/Response models


### PR DESCRIPTION
## Summary
- Fix positional argument bug where `discord_bot` was passed into the `memory` parameter slot of `AutonomousEngine.__init__`

## Problem
```python
# Before (line 700)
autonomous_engine = AutonomousEngine(claude, context_collector, discord_bot)
#                                                               ^^^^^^^^^^
#                                               lands in memory parameter → crash
```
- `self.memory` = `DiscordBot` object → `AttributeError: 'DiscordBot' object has no attribute 'get_context'`
- Autonomous loop crashes on first `think()` call

## Fix
```python
# After
autonomous_engine = AutonomousEngine(claude, context_collector, discord_bot=discord_bot)
```

## Test plan
- [ ] Run server with Discord bot configured
- [ ] Verify autonomous loop completes `think()` without errors
- [ ] Verify Discord notifications are sent correctly

Fixes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)